### PR TITLE
updated package name to effortless

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,4 +1,4 @@
-pkg_name=habitatize
+pkg_name=effortless
 pkg_origin=learn-chef
 pkg_scaffolding="core/scaffolding-ruby"
 pkg_version="0.1.0"


### PR DESCRIPTION
Updated the plan.sh to reflect a new naming scheme, "Effortless" instead of "Habitatize". Have also updated the modules that I'm aware use this repo:
chef-web-learn/hab-custom-config
chef-web-learn/hab-web-app-builder
chef-web-learn/hab-build-from-source